### PR TITLE
feat(pre-commit-hook): dont hardcode directory in hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,6 @@
     name: Generate Backlink Section in Markdown files
     description: This hook will lint Markdown files and generate a backlink Section
     entry: marko-backlinks
-    args: ["wikilink"]
     language: python
     types: [markdown]
     pass_filenames: false

--- a/cookiecutter-config-file.yml
+++ b/cookiecutter-config-file.yml
@@ -7,4 +7,4 @@ default_context:
   license: "MIT"
   version: "0.1.0"
   github_name: "jb-delafosse"
-  email: "dontcontactme@pouet.com"
+  email: "jean-baptiste@lumapps.com"


### PR DESCRIPTION
## Description

I hardcoded directory when defining the pre-commit hook.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [X] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/jb-delafosse/marko-backlinks/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/jb-delafosse/marko-backlinks/blob/master/CONTRIBUTING.md) guide.
- [X] I've updated the code style using `make codestyle`.
- [X] I've written tests for all new methods and classes that I created.
- [X] I've written the docstring in Google format for all the methods and classes that I used.
